### PR TITLE
Added incoming/outgoing label fields to product.product form view

### DIFF
--- a/product_labels_picking/__manifest__.py
+++ b/product_labels_picking/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     'data': [
         'views/product_template.xml',
+        'views/product_product.xml',
         'wizard/product_product_label_print.xml'
     ],
 }

--- a/product_labels_picking/views/product_product.xml
+++ b/product_labels_picking/views/product_product.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+
+        <record id="product_product_picking_label" model="ir.ui.view">
+            <field name="name">product.product.picking.label</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='codes']" position="after">
+                    <group name="label_picking">
+                        <group>
+                            <field name="label_incoming"/>
+                            <field name="label_outgoing"/>
+                        </group>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
I added the incoming and outgoing fields on the product.product form view, this way you can have a different configuration for variants of the same product template.